### PR TITLE
GS-16946 Include jira ticket description in post-jira-comment action

### DIFF
--- a/post-jira-comment/action.yml
+++ b/post-jira-comment/action.yml
@@ -5,6 +5,12 @@ inputs:
     description: The GitHub API token to use for authenticated requests
     default: ${{ github.token }}
     required: false
+  jira_user:
+    description: 'User for making requests to JIRA'
+    required: true
+  jira_password:
+    description: 'Password for making requests to JIRA'
+    required: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/post-jira-comment/dist/index.js
+++ b/post-jira-comment/dist/index.js
@@ -6346,7 +6346,8 @@ async function run()
                     var bodyString = `Link to JIRA Ticket: [${jiraTicketNumber}]\n\n`
                     bodyString += 'Please double check that your commits follow the [Git Commit Guidelines](https://socialgamingnetwork.jira.com/wiki/spaces/SFIOW/pages/1633026412/Git+Commit+Guidelines) :)\n\n'
                     bodyString += `[${jiraTicketNumber}]: https://socialgamingnetwork.jira.com/browse/${jiraTicketNumber}`
-                    bodyString += '---\n'
+                    bodyString += '\n\n---\n\n'
+                    bodyString += '**JIRA Ticket Description:**\n\n'
                     bodyString += jiraJSON.fields.description
 
                     core.info(`No comment found. Adding new comment: '${bodyString}'`)

--- a/post-jira-comment/dist/index.js
+++ b/post-jira-comment/dist/index.js
@@ -6146,7 +6146,7 @@ module.exports = eval("require")("encoding");
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("assert");;
+module.exports = require("assert");
 
 /***/ }),
 
@@ -6154,7 +6154,7 @@ module.exports = require("assert");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("events");;
+module.exports = require("events");
 
 /***/ }),
 
@@ -6162,7 +6162,7 @@ module.exports = require("events");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("fs");;
+module.exports = require("fs");
 
 /***/ }),
 
@@ -6170,7 +6170,7 @@ module.exports = require("fs");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("http");;
+module.exports = require("http");
 
 /***/ }),
 
@@ -6178,7 +6178,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("https");;
+module.exports = require("https");
 
 /***/ }),
 
@@ -6186,7 +6186,7 @@ module.exports = require("https");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("net");;
+module.exports = require("net");
 
 /***/ }),
 
@@ -6194,7 +6194,7 @@ module.exports = require("net");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("os");;
+module.exports = require("os");
 
 /***/ }),
 
@@ -6202,7 +6202,7 @@ module.exports = require("os");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("path");;
+module.exports = require("path");
 
 /***/ }),
 
@@ -6210,7 +6210,7 @@ module.exports = require("path");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("stream");;
+module.exports = require("stream");
 
 /***/ }),
 
@@ -6218,7 +6218,7 @@ module.exports = require("stream");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("tls");;
+module.exports = require("tls");
 
 /***/ }),
 
@@ -6226,7 +6226,7 @@ module.exports = require("tls");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("url");;
+module.exports = require("url");
 
 /***/ }),
 
@@ -6234,7 +6234,7 @@ module.exports = require("url");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("util");;
+module.exports = require("util");
 
 /***/ }),
 
@@ -6242,7 +6242,7 @@ module.exports = require("util");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("zlib");;
+module.exports = require("zlib");
 
 /***/ })
 
@@ -6281,12 +6281,15 @@ module.exports = require("zlib");;
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const core = __nccwpck_require__(24);
 const github = __nccwpck_require__(16);
+const fetch = __nccwpck_require__(460);
 
 
 async function run()
@@ -6325,18 +6328,40 @@ async function run()
             {
                 const jiraTicketNumber = jiraNumber[0];
 
-                var bodyString = `Link to JIRA Ticket: [${jiraTicketNumber}]\n\n`
-                bodyString += 'Please double check that your commits follow the [Git Commit Guidelines](https://socialgamingnetwork.jira.com/wiki/spaces/SFIOW/pages/1633026412/Git+Commit+Guidelines) :)\n\n'
-                bodyString += `[${jiraTicketNumber}]: https://socialgamingnetwork.jira.com/browse/${jiraTicketNumber}`
+                var request = {
+                    credentials: 'include',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Basic ${Buffer.from(`${core.getInput('jira_user')}:${core.getInput('jira_password')}`).toString('base64')}`,
+                    }
+                };
 
-                core.info(`No comment found. Adding new comment: '${bodyString}'`)
+                var jiraResponse = await fetch(`https://socialgamingnetwork.jira.com/rest/api/latest/issue/${jiraTicketNumber}?fields=description`, request);
+                var jiraJSON = await jiraResponse.json();
 
-                api.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    body: bodyString,
-                });
+                core.debug(jiraJSON);
+
+                if (jiraResponse.ok)
+                {
+                    var bodyString = `Link to JIRA Ticket: [${jiraTicketNumber}]\n\n`
+                    bodyString += 'Please double check that your commits follow the [Git Commit Guidelines](https://socialgamingnetwork.jira.com/wiki/spaces/SFIOW/pages/1633026412/Git+Commit+Guidelines) :)\n\n'
+                    bodyString += `[${jiraTicketNumber}]: https://socialgamingnetwork.jira.com/browse/${jiraTicketNumber}`
+                    bodyString += '---\n'
+                    bodyString += jiraJSON.fields.description
+
+                    core.info(`No comment found. Adding new comment: '${bodyString}'`)
+
+                    api.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                        body: bodyString,
+                    });
+                }
+                else
+                {
+                    core.setFailed('There was an issue with the JIRA API');
+                }
             }
         }
         else

--- a/post-jira-comment/index.js
+++ b/post-jira-comment/index.js
@@ -57,7 +57,8 @@ async function run()
                     var bodyString = `Link to JIRA Ticket: [${jiraTicketNumber}]\n\n`
                     bodyString += 'Please double check that your commits follow the [Git Commit Guidelines](https://socialgamingnetwork.jira.com/wiki/spaces/SFIOW/pages/1633026412/Git+Commit+Guidelines) :)\n\n'
                     bodyString += `[${jiraTicketNumber}]: https://socialgamingnetwork.jira.com/browse/${jiraTicketNumber}`
-                    bodyString += '---\n'
+                    bodyString += '\n\n---\n\n'
+                    bodyString += '**JIRA Ticket Description:**\n\n'
                     bodyString += jiraJSON.fields.description
 
                     core.info(`No comment found. Adding new comment: '${bodyString}'`)

--- a/post-jira-comment/package-lock.json
+++ b/post-jira-comment/package-lock.json
@@ -5,11 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "post-jira-comment",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.4.0",
-        "@actions/github": "^5.0.0"
+        "@actions/github": "^5.0.0",
+        "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@actions/core": {

--- a/post-jira-comment/package.json
+++ b/post-jira-comment/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@actions/core": "^1.4.0",
-    "@actions/github": "^5.0.0"
+    "@actions/github": "^5.0.0",
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
Making this for visibility since I don't want to leave it hanging while I'm on PTO. This adds the functionality to the `post-jira-comment` action to also include the JIRA ticket description in the comment itself (as seen in the image below). This works the same way as the action which checks for the documentation label. In the future we can factor out the common functionality if we plan to do more JIRA integrations.

![image](https://user-images.githubusercontent.com/17708436/132110569-6c3c32b1-06eb-47d3-bb4b-15584b06d772.png)
