### PR TITLE
GS-17868 - Add Windows Build to our Workflows

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TARGET_PLATFORM: ['Android', 'Amazon', 'OSX', 'iOS', 'WebGL']
+        TARGET_PLATFORM: ['Android', 'Amazon', 'OSX', 'iOS', 'WebGL', 'Windows']
         UNITY_VERSION: ['2019.4.28f1']
         include:
           - TARGET_PLATFORM: 'Android'
@@ -41,6 +41,10 @@ jobs:
 
           - TARGET_PLATFORM: 'WebGL'
             UNITY_PLATFORM: 'WebGL'
+            EXTRA_ARGUMENT: ''
+
+          - TARGET_PLATFORM: 'Windows'
+            UNITY_PLATFORM: 'StandaloneWindows64'
             EXTRA_ARGUMENT: ''
     env:
       TARGET_PACKAGE: 'JamCity.UnityCore.${{ inputs.sdk_name }}'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        UNITY_PLATFORM: ['Android', 'OSXUniversal', 'iOS', 'WebGL']
+        UNITY_PLATFORM: ['Android', 'OSXUniversal', 'iOS', 'WebGL', 'StandaloneWindows64']
         UNITY_VERSION: ['2019.4.28f1', '2020.3.14f1', '2021.1.15f1']
     env:
       TARGET_PACKAGE: 'JamCity.UnityCore.${{ inputs.sdk_name }}'


### PR DESCRIPTION
I have also already added the `windows-mono` module to all Unity installations on the build agents as well as updating the provisioning script to include it.