### PR TITLE
GS-18110 Remove hard-coded UnityCore references from actions

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -39,10 +39,10 @@ jobs:
         shell: bash
 
     env:
-      PROJECT_NAME: 'UnityCore.${{ inputs.sdk_name }}'
-      PACKAGE_NAME: 'JamCity.UnityCore.${{ inputs.sdk_name }}'
-      PROJECT_PATH: 'Assets/Plugins/JamCity/JamCity.UnityCore.${{ inputs.sdk_name }}'
-      RELEASE_PATH: 'Assets/Plugins/JamCity/JamCity.UnityCore.${{ inputs.sdk_name }}/Editor/Release'
+      PROJECT_NAME: '${{ inputs.sdk_name }}'
+      PACKAGE_NAME: 'JamCity.${{ inputs.sdk_name }}'
+      PROJECT_PATH: 'Assets/Plugins/JamCity/JamCity.${{ inputs.sdk_name }}'
+      RELEASE_PATH: 'Assets/Plugins/JamCity/JamCity.${{ inputs.sdk_name }}/Editor/Release'
 
     steps:
       - name: 'Validate Release Version'

--- a/.github/workflows/package-snapshot.yml
+++ b/.github/workflows/package-snapshot.yml
@@ -29,8 +29,8 @@ jobs:
         shell: bash
 
     env:
-      PACKAGE_NAME: 'JamCity.UnityCore.${{ inputs.sdk_name }}'
-      RELEASE_PATH: 'Assets/Plugins/JamCity/JamCity.UnityCore.${{ inputs.sdk_name }}/Editor/Release'
+      PACKAGE_NAME: 'JamCity.${{ inputs.sdk_name }}'
+      RELEASE_PATH: 'Assets/Plugins/JamCity/JamCity.${{ inputs.sdk_name }}/Editor/Release'
 
     steps:
       - name: 'Validate Snapshot Version'

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -47,7 +47,7 @@ jobs:
     name: 'Product catalog is up-to-date'
     runs-on: ['self-hosted', 'k8s-svc-runners-dind']
     env:
-      DOCUMENTATION_PATH: ${{ github.workspace }}/Assets/Plugins/JamCity/JamCity.UnityCore.${{ inputs.sdk_name }}/Editor/Documentation
+      DOCUMENTATION_PATH: ${{ github.workspace }}/Assets/Plugins/JamCity/JamCity.${{ inputs.sdk_name }}/Editor/Documentation
     steps:
       - name: 'Checkout Package'
         uses: actions/checkout@v2

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -47,11 +47,11 @@ jobs:
             UNITY_PLATFORM: 'StandaloneWindows64'
             EXTRA_ARGUMENT: ''
     env:
-      TARGET_PACKAGE: 'JamCity.UnityCore.${{ inputs.sdk_name }}'
+      TARGET_PACKAGE: 'JamCity.${{ inputs.sdk_name }}'
       UNITY_COMMAND: '/Applications/Unity/Hub/Editor/${{ matrix.UNITY_VERSION }}/Unity.app/Contents/MacOS/Unity -buildTarget ${{ matrix.UNITY_PLATFORM }} -projectPath ${{ github.workspace }} -batchmode -logfile -'
       EXECUTE_INSTALL_PACKAGE: '-executeMethod JamCity.UnityCoreTests.Editor.PackageCatalogUtility.InstallPackage -withParams'
       BUILD_PLAYER: '-executeMethod Builder.BuildPlayer${{ matrix.EXTRA_ARGUMENT }} -quit'
-      PACKAGE_PATH: '${{ github.workspace }}/Target/Assets/Plugins/JamCity/JamCity.UnityCore.${{ inputs.sdk_name }}'
+      PACKAGE_PATH: '${{ github.workspace }}/Target/Assets/Plugins/JamCity/JamCity.${{ inputs.sdk_name }}'
 
     steps:
       - name: 'Checkout UnityCoreTests'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,11 +26,11 @@ jobs:
         UNITY_PLATFORM: ['Android', 'OSXUniversal', 'iOS', 'WebGL', 'StandaloneWindows64']
         UNITY_VERSION: ['2019.4.28f1', '2020.3.14f1', '2021.1.15f1']
     env:
-      TARGET_PACKAGE: 'JamCity.UnityCore.${{ inputs.sdk_name }}'
+      TARGET_PACKAGE: 'JamCity.${{ inputs.sdk_name }}'
       UNITY_COMMAND: '/Applications/Unity/Hub/Editor/${{ matrix.UNITY_VERSION }}/Unity.app/Contents/MacOS/Unity -buildTarget ${{ matrix.UNITY_PLATFORM }} -projectPath ${{ github.workspace }} -batchmode -logfile -'
       EXECUTE_INSTALL_PACKAGE: '-executeMethod JamCity.UnityCoreTests.Editor.PackageCatalogUtility.InstallPackage -withParams'
-      PACKAGE_PATH: '${{ github.workspace }}/Target/Assets/Plugins/JamCity/JamCity.UnityCore.${{ inputs.sdk_name }}'
-      PLUGIN_PATH: '${{ github.workspace }}/Assets/Plugins/JamCity/JamCity.UnityCore.${{ inputs.sdk_name }}'
+      PACKAGE_PATH: '${{ github.workspace }}/Target/Assets/Plugins/JamCity/JamCity.${{ inputs.sdk_name }}'
+      PLUGIN_PATH: '${{ github.workspace }}/Assets/Plugins/JamCity/JamCity.${{ inputs.sdk_name }}'
       RUN_EDITOR_TESTS: '-runEditorTests -editorTestsResultFile'
       FILE_NAME: 'EditorTestResults_${{ matrix.UNITY_PLATFORM }}.xml'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 ### Changed
-- (GS-18039) Renamed documentation `index.md` to `README.md` so GitHub can find it. 
+- (GS-18039) Renamed documentation `index.md` to `README.md` so GitHub can find it.
+- (GS-18110) Removed hard-coded `UnityCore` references from workflow variables. 
 
 ### Deprecated
 


### PR DESCRIPTION
This should not be merged until all repositories using `@main` update their workflows.