### PR TITLE
Remove Windows from build matrix

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TARGET_PLATFORM: ['Android', 'Amazon', 'OSX', 'iOS', 'WebGL', 'Windows']
+        TARGET_PLATFORM: ['Android', 'Amazon', 'OSX', 'iOS', 'WebGL']
         UNITY_VERSION: ['2020.3.44f1']
         include:
           - TARGET_PLATFORM: 'Android'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        UNITY_PLATFORM: ['Android', 'OSXUniversal', 'iOS', 'WebGL', 'StandaloneWindows64']
+        UNITY_PLATFORM: ['Android', 'OSXUniversal', 'iOS', 'WebGL']
         UNITY_VERSION: ['2020.3.44f1', '2021.3.18f1']
     env:
       TARGET_PACKAGE: 'JamCity.${{ inputs.sdk_name }}'


### PR DESCRIPTION
Taking Windows off the build matrix. Keeping all our other Windows-specific logic in place in case we ever need to bring it back in.