### PR TITLE
Update to use node20

### DIFF
--- a/check-for-changelog/action.yml
+++ b/check-for-changelog/action.yml
@@ -10,5 +10,5 @@ inputs:
     default: CHANGELOG.md
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/check-for-documentation/action.yml
+++ b/check-for-documentation/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'Password for making requests to JIRA'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/post-github-comment/action.yml
+++ b/post-github-comment/action.yml
@@ -21,5 +21,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/post-jira-comment/action.yml
+++ b/post-jira-comment/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: false
     default: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/transition-jira-status/action.yml
+++ b/transition-jira-status/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: 'Password for making requests to JIRA'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Github Actions runners started throwing warnings that node16 needs to be updated to 20. I believe I've gotten most of them.